### PR TITLE
gemfileの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# gem "rails"
+
+ruby "2.7.2"
+
+group :development, :test do
+  gem "pry-byebug"
+  gem "rubocop-rails", require: false
+  gem "rubocop-rspec", require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,69 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.0.4.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    ast (2.4.2)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.2.2)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    json (2.6.3)
+    method_source (1.0.0)
+    minitest (5.17.0)
+    parallel (1.22.1)
+    parser (3.2.1.0)
+      ast (~> 2.4.1)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    rack (3.0.4.1)
+    rainbow (3.1.1)
+    regexp_parser (2.7.0)
+    rexml (3.2.5)
+    rubocop (1.46.0)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.2.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.26.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.26.0)
+      parser (>= 3.2.1.0)
+    rubocop-capybara (2.17.1)
+      rubocop (~> 1.41)
+    rubocop-rails (2.18.0)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.33.0, < 2.0)
+    rubocop-rspec (2.18.1)
+      rubocop (~> 1.33)
+      rubocop-capybara (~> 2.17)
+    ruby-progressbar (1.11.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.4.2)
+
+PLATFORMS
+  x86_64-darwin-19
+
+DEPENDENCIES
+  pry-byebug
+  rubocop-rails
+  rubocop-rspec
+
+RUBY VERSION
+   ruby 2.7.2p137
+
+BUNDLED WITH
+   2.3.21


### PR DESCRIPTION
## 概要
bundle initでgemfileを作成
gemでbinding.pryを使用するために"pry-byebug"を追加
コーディングを綺麗に描くために  
gem "rubocop-rails", require: false
gem "rubocop-rspec", require: false
を導入